### PR TITLE
Enable lazy matching for correct parsing destination path

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -62,7 +62,7 @@ chrome.downloads.onDeterminingFilename.addListener(function (downloadItem, sugge
 
         var result = true;
 
-        var filename = rule['pattern'].replace(/\$\{(\w+)(?::(.+))?\}/g, function (orig, field, idx) {
+        var filename = rule['pattern'].replace(/\$\{(\w+)(?::(.+?))?\}/g, function (orig, field, idx) {
             if (field === DATE_FIELD) {
                 if (idx) {
                     return moment(item.startTime).format(idx);


### PR DESCRIPTION
Hello. I found a bug in the regular expression that parse "Destination Path"

If the first placeholder in the template contains a `:`, then following placeholders will be read incorrectly. 
E.g:
`${date:YYYY.MM.DD} ${filename} `

This problem occurs because in expression `$\{(\w+)(?::(.+))?\}` activated greedy quantifier

Solution:
Add the `?` quantifier to the second group. In this way, the lazy matching is activated, instead of greedy.

PS You can see demo of parsing here https://regexr.com/472qr and see thats matching working incorrect